### PR TITLE
fixing dockerfile README formatting

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,9 +17,12 @@ Then run:
 Navigate to the root of a directory tree holding your imagery - for example if your data structure looks like:
 
 `/drone-images`
+
 `/drone-images/mission1/imagery/`
+
 `/drone-images/mission2/imagery/`
-`...``
+
+`...`
 
 ...navigate to `/drone-images`.
 


### PR DESCRIPTION
Directory tree description in docker README was flattened. This makes it readable.